### PR TITLE
Add Gmail bills to Telegram workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Required for the Telegram credential
+TELEGRAM_BOT_TOKEN=
+# Telegram chat ID where notifications will be sent
+TELEGRAM_CHAT_ID=
+
+# Optional Gmail search override (defaults to in:inbox is:unread newer_than:7d)
+GMAIL_QUERY=
+# Optional comma-separated keyword list for the classifier
+BILL_KEYWORDS=
+# Optional comma-separated whitelist of senders or domains
+ALLOWED_SENDERS=
+# Set to true to prevent Telegram messages and labels during testing
+DRY_RUN=false
+# Optional Gmail label ID for Bills/Auto (leave blank to use the label name)
+BILLS_LABEL_ID=

--- a/workflows/README_gmail_bills_to_telegram.md
+++ b/workflows/README_gmail_bills_to_telegram.md
@@ -1,0 +1,56 @@
+# Gmail → Bills → Telegram
+
+This workflow watches a Gmail inbox for bill-like messages and pings you on Telegram with a quick summary plus a link back to the thread. It keeps a small dedupe cache so the same email is not processed twice.
+
+## Files in this folder
+- `gmail_bills_to_telegram.json` – importable n8n workflow
+- `README_gmail_bills_to_telegram.md` – this setup guide
+
+## Prerequisites
+1. A self-hosted n8n instance (0.220+ recommended).
+2. Gmail access with API enabled and an OAuth2 credential inside n8n (type **Gmail OAuth2 API**).
+3. A Telegram bot token (create with [@BotFather](https://t.me/botfather)) and a chat ID to DM yourself.
+4. The environment variables listed in `.env.example` added to the n8n host (or your preferred secrets store).
+5. A Gmail label named **Bills/Auto** (create it once in Gmail or capture its ID via the Gmail node in n8n).
+
+## Environment variables
+Add the following to your n8n `.env` (or any secrets manager you use with credentials):
+
+- `TELEGRAM_BOT_TOKEN` – used in the Telegram credential (paste into the credential UI using the expression editor `{{ $env.TELEGRAM_BOT_TOKEN }}`).
+- `TELEGRAM_CHAT_ID` – numeric ID for the DM destination. To obtain it, send a message to your bot, then:
+  - Ask [@get_id_bot](https://t.me/get_id_bot) or [@userinfobot](https://t.me/userinfobot), **or**
+  - Call `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates` once and read the `chat.id` field.
+- Optional overrides:
+  - `GMAIL_QUERY` – custom Gmail search (defaults to `in:inbox is:unread newer_than:7d`).
+  - `BILL_KEYWORDS` – comma-separated keywords, e.g. `fatura,boleto,invoice,payment due`.
+  - `ALLOWED_SENDERS` – comma-separated whitelist of full emails or domains (e.g. `contato@meubanco.com,utility.com.br`). When set, keyword matching is skipped and only this list is used.
+  - `DRY_RUN` – set to `true` to log matches without hitting Telegram or labeling the email.
+  - `BILLS_LABEL_ID` – optional Gmail label ID if you already know it (e.g. `Label_123456789`). Leave unset to rely on the label name `Bills/Auto`.
+
+Restart n8n (or reload environment variables) after editing `.env` so the expressions resolve.
+
+## Import & credential hookup
+1. In n8n, go to **Workflows → Import from File** and choose `gmail_bills_to_telegram.json`.
+2. Open the **Trigger: Gmail (new emails)** node and pick your Gmail OAuth2 credential.
+3. Open the **Telegram: Send DM** node and select the Telegram credential that uses `{{ $env.TELEGRAM_BOT_TOKEN }}`.
+4. Save the workflow and enable it once you finish testing.
+
+## How to change the bill rules
+- **Adjust keywords**: Set `BILL_KEYWORDS` in your `.env` to a comma list, e.g. `BILL_KEYWORDS=fatura,boleto,cartão,payment due`. Restart n8n so the Function node picks them up.
+- **Whitelist senders**: Set `ALLOWED_SENDERS` to emails or domains (`bank@conta.com,@utility.com.br`) to only alert on those senders.
+- **Fine-tune the Gmail search**: override `GMAIL_QUERY`, for example `GMAIL_QUERY=in:inbox newer_than:14d has:attachment`.
+- **Dry run mode**: flip `DRY_RUN=true` to see matches in the execution log without contacting Telegram or adding the label.
+- **Label behaviour**: create the Gmail label **Bills/Auto** manually (Settings → Labels → Create new). If you know the label ID, drop it into `BILLS_LABEL_ID` so the Gmail node uses it directly.
+
+## Testing checklist
+1. Temporarily set `GMAIL_QUERY=from:me subject:(test bill)` and send yourself an email with a subject/body containing one of the keywords or an allowed sender.
+2. Enable `DRY_RUN=true` for the first run so you can inspect the execution without Telegram noise. Disable it afterwards to allow notifications.
+3. Add one of your banks or utilities to `ALLOWED_SENDERS` (e.g. `ALLOWED_SENDERS=contas@meubanco.com.br`) to verify whitelist detection.
+4. After import, run the workflow manually once from n8n to ensure the Gmail trigger, Function node, and Telegram node all resolve credentials correctly.
+5. Confirm that the Gmail node can add the **Bills/Auto** label. If Gmail requires the label ID, fetch it with a temporary Gmail node (`Label → Get All`) and set `BILLS_LABEL_ID` accordingly.
+6. When you are satisfied, revert `GMAIL_QUERY` to its default (or remove the env var) and set `DRY_RUN=false` before enabling the workflow.
+
+## Maintenance tips
+- The workflow keeps the last 500 processed Gmail message IDs in workflow static data to avoid duplicates. If you ever need to reprocess older mail, clear this cache via the n8n UI (Workflow → Settings → Reset workflow data).
+- Keywords, sender lists, and queries are all environment driven, so you can adjust behaviour without editing the workflow itself.
+- Telegram messages are plain text. Edit the **Telegram: Send DM** node if you prefer Markdown or want to include attachments.

--- a/workflows/gmail_bills_to_telegram.json
+++ b/workflows/gmail_bills_to_telegram.json
@@ -1,0 +1,167 @@
+{
+  "name": "Gmail → Bills → Telegram",
+  "nodes": [
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "event": "messageReceived",
+        "filters": {
+          "q": "={{ $env.GMAIL_QUERY ? $env.GMAIL_QUERY : 'in:inbox is:unread newer_than:7d' }}",
+          "readStatus": "unread"
+        },
+        "simple": true
+      },
+      "id": "b35f36be-027f-4d68-be7b-9a0324e3a43d",
+      "name": "Trigger: Gmail (new emails)",
+      "type": "n8n-nodes-base.gmailTrigger",
+      "typeVersion": 1.3,
+      "position": [
+        -520,
+        0
+      ],
+      "credentials": {
+        "gmailOAuth2": {
+          "name": "Gmail OAuth2"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "// Classify Gmail bills, keep last 500 IDs, and surface summary\nconst store = this.getWorkflowStaticData('global');\nconst seen = Array.isArray(store.processedIds) ? store.processedIds : (store.processedIds = []);\nconst limit = 500;\nconst fallbackKeywords = ['fatura','cobrança','boleto','vencimento','nota fiscal','invoice','statement','payment due','pagamento','mensalidade','conta',' NF '];\nconst keywordEnv = ($env.BILL_KEYWORDS || '').split(',').map((v) => v.trim()).filter(Boolean);\nconst keywords = keywordEnv.length ? keywordEnv : fallbackKeywords;\nconst normalizedKeywords = keywords.map((k) => k.normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').toLowerCase());\nconst allowedSenders = ($env.ALLOWED_SENDERS || '').split(',').map((v) => v.trim().toLowerCase()).filter(Boolean);\nconst dryRun = String($env.DRY_RUN || '').toLowerCase() === 'true';\nconst normalize = (val) => (val || '').toString().normalize('NFD').replace(/[\\u0300-\\u036f]/g, '').toLowerCase();\nconst stripHtml = (val) => (val || '').replace(/<[^>]+>/g, ' ');\nconst decode = (val) => {\n  if (!val) return '';\n  try {\n    return Buffer.from(val.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');\n  } catch (error) {\n    return '';\n  }\n};\nconst collectBody = (payload) => {\n  if (!payload) return '';\n  let text = '';\n  const queue = [payload];\n  while (queue.length && text.length < 5000) {\n    const part = queue.shift();\n    if (!part) continue;\n    if (part.body?.data) text += '\\n' + decode(part.body.data);\n    if (Array.isArray(part.parts)) queue.push(...part.parts);\n  }\n  return stripHtml(text).slice(0, 5000);\n};\nconst parseEmail = (raw) => {\n  const result = { address: '', name: '' };\n  if (!raw) return result;\n  const match = raw.match(/<?([^<>\\s]+@[^<>\\s]+)>?/);\n  if (match) result.address = match[1].toLowerCase();\n  const namePart = raw.split('<')[0].replace(/\"/g, '').trim();\n  if (namePart && !namePart.includes('@')) result.name = namePart;\n  if (!result.name && result.address) result.name = result.address.split('@')[0];\n  return result;\n};\nconst findMatch = (text, patterns) => {\n  for (const pattern of patterns) {\n    const match = text.match(pattern);\n    if (match?.[0]) return match[0].trim();\n  }\n  return '';\n};\nconst results = [];\nfor (const item of items) {\n  const message = item.json || {};\n  const messageId = message.id || message.messageId;\n  if (!messageId || seen.includes(messageId)) continue;\n  const threadId = message.threadId || message.thread?.id || '';\n  const fromHeader = message.from || message.From || '';\n  const subject = message.subject || message.Subject || '';\n  const payload = message.payload || {};\n  const snippet = message.snippet || '';\n  const body = collectBody(payload) || (payload.body?.data ? stripHtml(decode(payload.body.data)).slice(0, 5000) : '');\n  const combined = `${subject}\\n${snippet}\\n${body}`.slice(0, 5000);\n  const normalized = normalize(`${fromHeader}\\n${combined}`);\n  const sender = parseEmail(fromHeader);\n  let isBill = false;\n  let reason = '';\n  if (allowedSenders.length) {\n    const email = sender.address;\n    const domain = email.split('@')[1] || '';\n    for (const entry of allowedSenders) {\n      const target = entry.replace(/^@/, '');\n      if ((entry.includes('@') && email === entry) || domain === target || email.endsWith(`@${target}`)) {\n        isBill = true;\n        reason = `sender:${entry}`;\n        break;\n      }\n    }\n  } else {\n    for (let index = 0; index < normalizedKeywords.length; index++) {\n      if (normalized.includes(normalizedKeywords[index])) {\n        isBill = true;\n        reason = `keyword:${keywords[index]}`;\n        break;\n      }\n    }\n  }\n  const amount = findMatch(combined, [/R\\$ ?\\d{1,3}(?:\\.\\d{3})*,\\d{2}/gi,/\\b\\d{1,3}(?:\\.\\d{3})*,\\d{2}\\b/g,/\\b\\d+\\.\\d{2}\\b/g]);\n  const dueMatches = [\n    /(vencimento|due date|payment due)[:\\s-]*([0-9]{1,2}[\\/.-][0-9]{1,2}(?:[\\/.-][0-9]{2,4})?)/i,\n    /\\b[0-9]{1,2}[\\/.-][0-9]{1,2}[\\/.-][0-9]{2,4}\\b/,\n    /\\b[0-9]{1,2}[\\/.-][0-9]{1,2}\\b/,\n    /\\b[0-9]{1,2} de [a-zç]+\\b/i,\n  ];\n  let dueDate = '';\n  for (const pattern of dueMatches) {\n    const match = combined.match(pattern);\n    if (match) {\n      dueDate = (match[2] || match[0] || '').trim();\n      break;\n    }\n  }\n  const output = {\n    isBill,\n    reason: reason || (isBill ? 'matched' : 'no-match'),\n    amount: amount || '',\n    dueDate: dueDate || '',\n    from: fromHeader,\n    subject,\n    snippet,\n    gmailLink: threadId ? `https://mail.google.com/mail/u/0/#inbox/${threadId}` : `https://mail.google.com/mail/u/0/#inbox/${messageId}`,\n    messageId,\n    threadId: threadId || '',\n    dryRun,\n  };\n  if (sender.name) output.fromName = sender.name;\n  if (dryRun && isBill) output.reason = `${output.reason} (dry-run)`;\n  seen.push(messageId);\n  if (seen.length > limit) seen.splice(0, seen.length - limit);\n  results.push({ json: output });\n}\nreturn results;\n"
+      },
+      "id": "b82865a0-c03d-46b2-8332-9af5889193d5",
+      "name": "Function: Classify Bill",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        -260,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json[\"isBill\"] }}",
+              "operation": "equal",
+              "value2": true
+            },
+            {
+              "value1": "={{ $json[\"dryRun\"] ? true : false }}",
+              "operation": "equal",
+              "value2": false
+            }
+          ]
+        }
+      },
+      "id": "51a55145-5348-4771-be9c-6a3ba6b74837",
+      "name": "IF: Is Bill?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "chatId": "={{ $env.TELEGRAM_CHAT_ID }}",
+        "text": "={{ ['📬 Possible bill detected','From: ' + ($json.from || '—'),'Subject: ' + ($json.subject || '—'),'Amount: ' + ($json.amount || '—'),'Due: ' + ($json.dueDate || '—'),'Why: ' + ($json.reason || '—'),'Open: ' + ($json.gmailLink || '—')].join('\\n') }}",
+        "additionalFields": {}
+      },
+      "id": "fc9b9562-902d-459a-8abb-d724d5c12900",
+      "name": "Telegram: Send DM",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [
+        260,
+        -100
+      ],
+      "credentials": {
+        "telegramApi": {
+          "name": "Telegram Bot"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "addLabels",
+        "messageId": "={{ $json[\"messageId\"] }}",
+        "labelIds": [
+          "={{ $env.BILLS_LABEL_ID ? $env.BILLS_LABEL_ID : 'Bills/Auto' }}"
+        ]
+      },
+      "id": "6424ae50-3014-47a1-84cc-b616fa52b32b",
+      "name": "Gmail: Add Label Bills/Auto",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2.1,
+      "position": [
+        520,
+        -100
+      ],
+      "credentials": {
+        "gmailOAuth2": {
+          "name": "Gmail OAuth2"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Trigger: Gmail (new emails)": {
+      "main": [
+        [
+          {
+            "node": "Function: Classify Bill",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function: Classify Bill": {
+      "main": [
+        [
+          {
+            "node": "IF: Is Bill?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF: Is Bill?": {
+      "main": [
+        [
+          {
+            "node": "Telegram: Send DM",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Telegram: Send DM": {
+      "main": [
+        [
+          {
+            "node": "Gmail: Add Label Bills/Auto",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "pinData": {},
+  "id": 1,
+  "meta": {
+    "instanceId": "7a028641-f6a5-4ddc-869e-e46142890a0a"
+  },
+  "versionId": "94029994-8ea3-4e74-b3bb-09297e0ed199",
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- add an importable n8n workflow that watches Gmail for bill-like messages and relays summaries to Telegram
- document setup, environment variables, and testing guidance for the workflow
- provide an example .env file listing the required configuration values

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9459dac34832a81559cfc767a6f01